### PR TITLE
Set permission to production domains only when releasing

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Digipost",
   "name": "Digipost ende-til-ende-kryptering",
   "description": "Dekrypter ende-til-ende-krypterte meldinger i Digipost direkte i nettleseren din!",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "icons": {
     "16": "icons/app16.png",
     "48": "icons/app48.png",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Digipost",
   "name": "Digipost ende-til-ende-kryptering",
   "description": "Dekrypter ende-til-ende-krypterte meldinger i Digipost direkte i nettleseren din!",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "icons": {
     "16": "icons/app16.png",
     "48": "icons/app48.png",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,23 @@
 var gulp = require('gulp');
+var gutil = require('gulp-util');
+
+var taskListing = require('gulp-task-listing');
 
 var jshint = require('gulp-jshint');
 var stylish = require('jshint-stylish');
-var taskListing = require('gulp-task-listing');
+
+var through = require('through2');
+
 var zip = require('gulp-zip');
-var del = require('del');
+
 var git = require('gulp-git');
 var bump = require('gulp-bump');
 var tag_version = require('gulp-tag-version');
+
+var ncp = require('ncp').ncp;
+var del = require('del');
+var mkdirp = require('mkdirp');
+
 var yargs = require('yargs');
 var runSequence = require('run-sequence');
 
@@ -18,22 +28,32 @@ gulp.task('lint', function() {
 		.pipe(jshint.reporter('fail'));
 });
 
-gulp.task('package', ['clean'], function() {
-	console.log('Packaging the extension to the dist folder');
-	return gulp.src('extension/**')
-		.pipe(zip('extension.zip'))
-		.pipe(gulp.dest('dist'))
+gulp.task('package', ['copy', 'clean'], function() {
+		return gulp.src('dist/build/**')
+			.pipe(zip('extension.zip'))
+			.pipe(gulp.dest('dist'))
 });
 
-gulp.task('clean', function(callback) {
+gulp.task('copy', ['clean'], function(cb) {
+	console.log('Packaging the extension to the dist folder');
+
+	mkdirp('dist/build', function (mkdirErr) {
+		ncp('extension', 'dist/build', function (copyErr) {
+			if (mkdirErr || copyErr) return console.error("Unable to copy extension folder", mkdirErr, copyErr);
+			cb();
+		});
+	});
+});
+
+gulp.task('clean', function (callback) {
 	del(['dist/'], callback);
 });
 
-gulp.task('bump', function() {
+gulp.task('bump', function () {
 	var importance = yargs.argv.ver;
 	const possibleImportances = ['patch', 'minor', 'major'];
 
-	if (!importance || possibleImportances.indexOf(importance) == -1) {
+	if (!importance || possibleImportances.indexOf(importance) == -1) {
 		var defaultImportance = possibleImportances[0];
 		console.log('No or invalid version type provided. Using ' + defaultImportance + '. To specify your own, specify --ver=[' + possibleImportances.join('|') + ']');
 		importance = defaultImportance;
@@ -42,11 +62,20 @@ gulp.task('bump', function() {
 	return inc(importance);
 });
 
-gulp.task('release', function(callback) {
-	runSequence('lint', 'bump', 'package', function() {
+gulp.task('release', function (callback) {
+	runSequence('lint', 'bump', 'copy', 'permissions', 'package', function () {
 		console.log('Done releasing! Nothing has been pushed to Github, so please review the release manually and push or rollback. Remember to delete the tag if you want to roll back the release.');
 		if (typeof callback == 'function') callback.apply(this, arguments);
 	});
+});
+
+gulp.task('permissions', function () {
+	return gulp.src('dist/build/manifest.json')
+		.pipe(manifest_urls({
+				permission_urls: ['https://www.digipost.no/*', 'https://www.digipostdata.no/*'],
+				content_script_urls: ['https://www.digipost.no/*']
+			}))
+		.pipe(gulp.dest('dist/build'));
 });
 
 gulp.task('default', taskListing);
@@ -56,6 +85,36 @@ function inc(importance) {
 		// Bump version numbers in files with version
 		.pipe(bump({type: importance}))
 		.pipe(gulp.dest('./extension'))
-	 	.pipe(git.commit('Released new version'))
-	 	.pipe(tag_version());
+		.pipe(git.commit('Released new version'))
+		.pipe(tag_version());
+}
+
+
+/**
+ * Overrides permission and matching URLs in manifest files to avoid publishing version with development URLs.
+ */
+function manifest_urls(options) {
+	return through.obj(function (file, enc, cb) {
+		var manifestJson = JSON.parse(file.contents.toString());
+
+		manifestJson.permissions = manifestJson.permissions.filter(removeUrls).concat(options.permission_urls);
+
+		if (manifestJson.content_scripts.length != 1) {
+			return cb(new gutil.PluginError('gulpfile.js', 'We only support exactly one content script block.', {
+				fileName: file.path,
+				showStack: true
+			}));
+		}
+		manifestJson.content_scripts[0].matches = manifestJson.content_scripts[0].matches.filter(removeUrls).concat(options.content_script_urls);
+
+		file.contents = new Buffer(JSON.stringify(manifestJson, null, '  ') + '\n');
+
+		gutil.log('Set permission URLs to  ' + gutil.colors.cyan(options.permission_urls.join(', ')) + ' and content script URLs to ' + gutil.colors.cyan(options.content_script_urls.join(', ')));
+		return cb(null, file);
+	});
+
+	function removeUrls(item) {
+		return item.indexOf('http://') == -1 && item.indexOf('https://') == -1
+	}
+
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,13 +34,13 @@ gulp.task('package', function() {
 			.pipe(gulp.dest('dist'))
 });
 
-gulp.task('copy', function(cb) {
+gulp.task('copy', function(callback) {
 	console.log('Packaging the extension to the dist folder');
 
 	mkdirp('dist/build', function (mkdirErr) {
 		ncp('extension', 'dist/build', function (copyErr) {
 			if (mkdirErr || copyErr) return console.error("Unable to copy extension folder", mkdirErr, copyErr);
-			cb();
+			callback();
 		});
 	});
 });
@@ -94,13 +94,13 @@ function inc(importance) {
  * Overrides permission and matching URLs in manifest files to avoid publishing version with development URLs.
  */
 function manifest_urls(options) {
-	return through.obj(function (file, enc, cb) {
+	return through.obj(function (file, enc, callback) {
 		var manifestJson = JSON.parse(file.contents.toString());
 
 		manifestJson.permissions = manifestJson.permissions.filter(removeUrls).concat(options.permission_urls);
 
 		if (manifestJson.content_scripts.length != 1) {
-			return cb(new gutil.PluginError('gulpfile.js', 'We only support exactly one content script block.', {
+			return callback(new gutil.PluginError('gulpfile.js', 'We only support exactly one content script block.', {
 				fileName: file.path,
 				showStack: true
 			}));
@@ -110,7 +110,7 @@ function manifest_urls(options) {
 		file.contents = new Buffer(JSON.stringify(manifestJson, null, '  ') + '\n');
 
 		gutil.log('Set permission URLs to  ' + gutil.colors.cyan(options.permission_urls.join(', ')) + ' and content script URLs to ' + gutil.colors.cyan(options.content_script_urls.join(', ')));
-		return cb(null, file);
+		return callback(null, file);
 	});
 
 	function removeUrls(item) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,13 +28,13 @@ gulp.task('lint', function() {
 		.pipe(jshint.reporter('fail'));
 });
 
-gulp.task('package', ['copy', 'clean'], function() {
+gulp.task('package', function() {
 		return gulp.src('dist/build/**')
 			.pipe(zip('extension.zip'))
 			.pipe(gulp.dest('dist'))
 });
 
-gulp.task('copy', ['clean'], function(cb) {
+gulp.task('copy', function(cb) {
 	console.log('Packaging the extension to the dist folder');
 
 	mkdirp('dist/build', function (mkdirErr) {
@@ -63,7 +63,7 @@ gulp.task('bump', function () {
 });
 
 gulp.task('release', function (callback) {
-	runSequence('lint', 'bump', 'copy', 'permissions', 'package', function () {
+	runSequence('lint', 'bump', 'clean', 'copy', 'permissions', 'package', function () {
 		console.log('Done releasing! Nothing has been pushed to Github, so please review the release manually and push or rollback. Remember to delete the tag if you want to roll back the release.');
 		if (typeof callback == 'function') callback.apply(this, arguments);
 	});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp-zip": "^3.0.2",
     "jshint-stylish": "^1.0.1",
     "mkdirp": "^0.5.0",
+    "ncp": "^2.0.0",
     "run-sequence": "^1.0.2",
     "through2": "^0.6.5",
     "yargs": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,12 @@
     "gulp-jshint": "^1.10.0",
     "gulp-tag-version": "^1.2.1",
     "gulp-task-listing": "^1.0.0",
+    "gulp-util": "^3.0.4",
     "gulp-zip": "^3.0.2",
     "jshint-stylish": "^1.0.1",
+    "mkdirp": "^0.5.0",
     "run-sequence": "^1.0.2",
+    "through2": "^0.6.5",
     "yargs": "^3.7.2"
   },
   "scripts": {


### PR DESCRIPTION
This allows us to use development domains like localhost and qa.digipost.no when doing development on the extension, while only publishing to web store for production domains (to avoid a big and confusing permission list).